### PR TITLE
fix: export `postcss` as true

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,3 +66,5 @@ module.exports = () => {
 		},
 	};
 };
+
+module.exports.postcss = true


### PR DESCRIPTION
This will solve the problem that the plugin does not run in some environments.

## Reproduction

### StackBlitz
https://stackblitz.com/edit/nextjs-wguqmt

### Local
1. `pnpm create next-app --tailwind`
2. `pnpm i -D postcss-prune-var`
3. Add `'postcss-prune-var': {},` to `postcss.config.js`
4. `pnpm dev`

Ref: https://postcss.org/docs/writing-a-postcss-plugin