### PR TITLE
feat: options to skip some files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ const yourConfig = {
 };
 ```
 
+## Options
+
+### skip
+
+Use this option to exclude certain files or folders that would otherwise be scanned.
+
+```js
+const pruneVar = require('postcss-prune-var');
+
+const yourConfig = {
+	plugins: [pruneVar({skip: ['node_modules/**']})],
+};
+```
 ## Example
 
 Input:

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const {minimatch} = require("minimatch");
+const path = require("path");
 /**
  * @typedef {object} UseRecord
  * @property {number} uses
@@ -5,10 +7,14 @@
  * @property {Set<string>} dependencies
  */
 
-module.exports = () => {
+module.exports = (options) => {
 	return {
 		postcssPlugin: 'postcss-prune-var',
 		Once(root) {
+			const { skip = [] } = options;
+			if (skip.some((s) => minimatch(path.relative(process.cwd(), root.source.input.from), s, {dot: true}))) {
+				return;
+			}
 			/** @type Map<string, UseRecord> */
 			const records = new Map();
 

--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ const path = require("path");
  * @property {Set<string>} dependencies
  */
 
-module.exports = (options) => {
+module.exports = (options = {}) => {
 	return {
 		postcssPlugin: 'postcss-prune-var',
 		Once(root) {
-			const { skip = [] } = options;
+			const {skip = []} = options;
 			if (skip.some((s) => minimatch(path.relative(process.cwd(), root.source.input.from), s, {dot: true}))) {
 				return;
 			}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	},
 	"homepage": "https://github.com/tomasklaen/postcss-prune-var#readme",
 	"devDependencies": {
+		"minimatch": "^9.0.0",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.4.14"
 	}

--- a/test.js
+++ b/test.js
@@ -42,4 +42,32 @@ async function test() {
 	assert.equal(result.css, output, `Result different than expected`);
 }
 
+async function testFileFiltering() {
+	const output = `
+:root {
+	--root-unused: red;
+	--root-unused-proxy: var(--root-unused);
+	--root-used: blue;
+	--unused-duplicate: yellow;
+	--circular: var(--circular);
+	color: var(--circular);
+}
+.foo {
+	--unused: red;
+	--unused-proxy: var(--unused);
+	--proxied: pink;
+	--proxy: var(--proxied);
+	--used: green;
+	--unused-duplicate: yellow;
+	color: var(--root-used);
+	background: linear-gradient(to bottom, var(--used), var(--proxy));
+}
+`;
+
+	const result = await postcss([pruneVar({skip: ['fixtures/**']})]).process(output, {from: 'fixtures/test.css', to: 'out.css'});
+	assert.strictEqual(result.css, output, `Result different than expected`);
+	
+}
+
 test();
+testFileFiltering();


### PR DESCRIPTION
Sometimes, we need to skip files. 

For example, this [lib](https://github.com/vercel-labs/react-tweet) with nextjs, it put css variable in `theme.css` and use variable in other module css. Since these css files not be merged, postcss-prune-var will remove variable in theme.css, and cause a bug that other module css can not find variable.

ps: Sorry for my pool english.